### PR TITLE
05-lu-05_Update 02-03-learning_objectives.adoc

### DIFF
--- a/docs/05-lu-05_example_scenarios_and_exercises/02-03-learning_objectives.adoc
+++ b/docs/05-lu-05_example_scenarios_and_exercises/02-03-learning_objectives.adoc
@@ -37,8 +37,8 @@ T3P should be able to select, design and/or adapt exercises that
 
 * support selected topics and LGs,
 * adapt the didactic method,
-* activate participants.
-
-
+* activates students’ participations
+* facilitates understanding of relation to CPSA-F important LGs and delineate the expected outcome
+* are covered at right context and within the timeline
 
 // end::EN[]


### PR DESCRIPTION
From the Rummage box:
LU 9. LU Designing and Evaluating Example Scenarios is covered under LG 5-1 to 5-4

LU 10. LU Creating Exercises based on an Example Scenario can be covered under LG 5-5: Provide stand-alone exercises

Few suggested amendments to LG 5-5 are as follows in bold:  T3P should be able to select, design and/or adapt exercises that

• support selected topics and LGs,
• adapt the didactic method,
**• activates students’ participations
• facilitates understanding of relation to CPSA-F important LGs and delineate the expected outcome
• are covered at right context and within the timeline**

3. Other Leftovers section looks covered in LG 5-1 to LG 5-5

Reference issue #10 