### PR TITLE
Add Literature refs for LU03, refs #35

### DIFF
--- a/docs/03-lu-03_didactics_methods_tools/02-06-discussion_points.adoc
+++ b/docs/03-lu-03_didactics_methods_tools/02-06-discussion_points.adoc
@@ -130,9 +130,7 @@ a|* Use parking lot technique for off-topic discussions
 * Provide additional resources for deeper exploration
 |===
 
-===== Escalation Guidelines
-
-====== When to Escalate
+===== Escalation Guidelines - When to Escalate
 
 Know when to escalate issues:
 
@@ -141,7 +139,7 @@ Know when to escalate issues:
 * Technical infrastructure problems
 * Health or safety concerns
 
-====== Escalation Process
+===== Escalation Guidelines - Escalation Process
 
 1. Document the situation
 2. Consult with co-trainers if available

--- a/docs/03-lu-03_didactics_methods_tools/02-08-references.adoc
+++ b/docs/03-lu-03_didactics_methods_tools/02-08-references.adoc
@@ -9,6 +9,56 @@ Web sources, Videos, Books, etc. that helps the trainer to prepare the content o
 // end::REMARK[]
 
 // tag::EN[]
-* Hunter, Bailey, Taylor (1995). "The Art of Facilitation: How to Create Group Synergy"
-* Bowman (2008). "Training from the Back of the Room!"
+
+==== Core Didactic References - Modern Sources on Adult Learning and Didactics
+
+These sources cover essential didactic concepts and modern methods for training software architects.
+
+Brown et al. - Make It Stick <<brown_makeitstick>>::
+A research-backed book on the psychology of learning, providing insights into **effective knowledge retention strategies**.
+Essential for LG 3-1 (Adult Learning) and LG 3-3 (Attention and Learning Performance).
+
+Bowman - Training from the Back of the Room <<bowman>>::
+A **practical guide to interactive and engaging teaching methods** for adult learners.
+Supports <<LG-3-5, LG 3-5 (Training Methods)>> and <<LG-3-6, LG 3-6 (Communication and Presentation Skills)>>.
+
+Dirksen - Design for How People Learn <<dirksen_design>>::
+A **practical book on learning design**, explaining how adults learn and how training methods should be adapted.
+Supports <<LG-3-1, LG 3-1 (Adult Learning>> and <<LG-3-5, LG 3-5 (Training Methods)>>.
+
+Fink - Creating Significant Learning Experiences <<fink_creating>>::
+A **modern perspective on goal-oriented didactics**, highly useful for structuring training sessions. 
+Aligns with <<LG-3-2, LG 3-2 (Learning Objectives)>> and <<LG-3-5, LG 3-5 (Training Methods)>>.
+
+Gee - The Anti-Education Era <<gee_antieducation>>::
+A critical discussion of **modern learning formats and digital teaching methods**, useful for online and hybrid training.
+Relevant to <<LG-3-5, LG 3-5 (Training Methods)>> and <<LG-3-4, LG 3-4 (Distraction Factors)>>.
+
+Hunter et al. - The Art of Facilitation <<hunter_facilitation>>::
+A fundamental work on **facilitation techniques and group dynamics**, valuable for understanding how to guide interactive learning sessions.
+Supports <<LG-3-5, LG 3-5 (Training Methods)>> and <<LG-3-6, LG 3-6 (Communication)>>.
+
+==== Architecture Teaching References - Modern Sources for Teaching Architectural Thinking
+
+These books focus on effective strategies for software architecture.
+Use them to illustrate the content of LU02.
+
+Richards/Ford - Fundamentals of Software Architecture <<richards_fundamentals>>::
+Provides a comprehensive guide to software architecture, covering both technical aspects (patterns, components, engineering practices) and practical considerations (team management, presentations, metrics), with principles applicable across technology stacks.
+
+Ford et al. - Software Architecture: The Hard Parts <<ford_hardparts>>::
+Covers **practical challenges in architecture decision-making**, ideal for **interactive discussions in training**.
+More suited for advanced learners as this is primarily about the trade-offs of distributed systems.
+
+Bass et al. - Software Architecture in Practice <<bass>>::
+Provides a comprehensive theoretical and practical foundation for software architecture, covering both fundamental principles and their application to modern technological challenges (like mobility, cloud, and DevOps). The book emphasizes architecture's role in achieving quality attributes and managing system evolution.
+
+Starke et al. - arc42 by Example <<arc42BE1>>::
+A **collection of real-world architectural case studies** that can be used in training.
+
+Neward et al. - Architectural Katas <<katas_neward>>::
+**Interactive architecture exercises**, ideal for **active learning methods** in software architecture training.
+Supports <<LG-3-5, LG 3-5 (Training Methods)>>.
+
+
 // end::EN[]

--- a/docs/05-lu-05_example_scenarios_and_exercises/02-08-references.adoc
+++ b/docs/05-lu-05_example_scenarios_and_exercises/02-08-references.adoc
@@ -11,7 +11,7 @@ Web sources, Videos, Books, etc. that helps the trainer to prepare the content o
 // tag::EN[]
 * The arc42 website <<arc42>> contains links to several online examples.
 * Both arc42 by Example books <<arc42BE1>>, <<arc42BE2>> provide description of different IT systems.
-* The architectural katas from Ted Neward <<katas2>> or Mark Richards and Neal Ford <<katas1>> might provide some inspiration.
+* The architectural katas from Ted Neward <<katas_neward>> or Mark Richards and Neal Ford <<katas1>> might provide some inspiration.
 * The collection 'The Architecture of Open Source Applications' <<aosa>> offers a veritable cornucopia of insightful examples.
 
 // end::EN[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -27,44 +27,53 @@
 - [[[bachmann, Bachmann+2000]]] F. Bachmann et al., "Software Architecture Documentation in Practice: Documenting Architectural Layers," Software Engineering Institute, Carnegie Mellon University, Pittsburgh, PA, USA, Tech. Rep. CMU/SEI-2000-SR-004, Mar. 2000. [Online]. Available: https://insights.sei.cmu.edu/documents/5437/2000_003_001_13649.pdf
 - [[[bass, Bass+2021]]] L. Bass, P. Clements, and R. Kazman, _Software Architecture in Practice_, 4th ed. Boston, MA, USA: Addison Wesley, 2021.
 - [[[bowman, Bowman 2008]]] S. Bowman, _Training from the Back of the Room! 65 Ways to Step Aside and Let Them Learn_. San Francisco, CA, USA: Pfeiffer, 2008.
+- [[[brown_makeitstick,Brown+2014]]] P. C. Brown, H. L. Roediger, and M. A. McDaniel, _Make It Stick: The Science of Successful Learning_. Cambridge, MA, USA: Harvard Univ. Press, 2014.
+
+// D
+- [[[dirksen_design,Dirksen 2016]]] J. Dirksen, _Design for How People Learn_, 2nd ed. San Francisco, CA, USA: New Riders, 2016.
 
 // F
-- [[[ford,Ford+2021]]] N. Ford, M. Richards, P. Sadalage, and Z. Dehghani, _Software Architecture: The Hard Parts_. Sebastopol, CA, USA: O'Reilly Media, 2021.
+- [[[fink_creating,Fink 2013]]] L. D. Fink, _Creating Significant Learning Experiences: An Integrated Approach to Designing College Courses_, 2nd ed. San Francisco, CA, USA: Jossey-Bass, 2013.
+- [[[ford_hardparts,Ford+2021]]] N. Ford, M. Richards, P. Sadalage, and Z. Dehghani, _Software Architecture: The Hard Parts_. Sebastopol, CA, USA: O'Reilly Media, 2021.
+
+// G
+- [[[gee_antieducation,Gee 2013]]] J. P. Gee, _The Anti-Education Era: Creating Smarter Students through Digital Learning_. New York, NY, USA: Palgrave Macmillan, 2013.
 
 // H
 - [[[hase,Hase+2000]]] S. Hase and C. Kenyon, "From andragogy to heutagogy," _Ultibase Articles_, vol. 5, pp. 1-10, 2000. [Online]. Available: https://webarchive.nla.gov.au/awa/20010220130000/http://ultibase.rmit.edu.au/Articles/dec00/hase2.htm
-- [[[arc42BE2, Hruschka+2021]]] P. Hruschka, I. Kostov, and W. Reimesch, _Arc42 by Example Volume 2: Architecture Documentation for Embedded Systems and IoT_. Victoria, BC, Canada: Leanpub, 2021. [Online]. Available: https://leanpub.com/arc42byexample-volume2A
+- [[[arc42BE2, Hruschka+2021]]] P. Hruschka, I. Kostov, and W. Reimesch, _Arc42 by Example Volume 2: Architecture Documentation for Embedded Systems and IoT_. Victoria, BC, Canada: Leanpub, 2021. [Online]. Available: https://leanpub.com/arc42byexample-volume2
+- [[[hunter_facilitation,Hunter+1995]]] D. Hunter, A. Bailey, and B. Taylor, _The Art of Facilitation: How to Create Group Synergy_. Cambridge, MA, USA: Perseus Books, 1995.
 
 // I
 - [[[isaqbFLC, iSAQB-FLC]]] International Software Architecture Qualification Board (iSAQB), "Foundation Level Curriculum." [Online]. Available: https://public.isaqb.org/curriculum-foundation/
 
-// TODO continue here with formatting according to IEEE style
-
-- [[[kruchten, Kruchten 1995]]] Kruchten, P.: Architectural Blueprints – The 4-1 View Model of Architecture. IEEE Software November 1995; 12(6), p. 42-50.
-
-// this reference is for dealing with adult learners that do not have an academic background
+// K
+- [[[kruchten, Kruchten 1995]]] P. Kruchten, "Architectural Blueprints - The 4+1 View Model of Software Architecture," IEEE Softw., vol. 12, no. 6, pp. 42-50, Nov. 1995.
+// The follwoing reference is for dealing with adult learners that do not have an academic background
 // Todo: find a good place to integrate its TLDR in the curriculum and to reference it
-- [[[kenner, Kenner+2011]]] Kenner, C., & Weinerman, J. (2011). Adult learning theory: Applications to non-traditional college students. Journal of College Reading and Learning, 41(2), 87-96. https://files.eric.ed.gov/fulltext/EJ926365.pdf
+- [[[kenner, Kenner+2011]]] C. Kenner and J. Weinerman, "Adult learning theory: Applications to non-traditional college students," J. College Reading Learning, vol. 41, no. 2, pp. 87-96, 2011. [Online]. Available: https://files.eric.ed.gov/fulltext/EJ926365.pdf
+- [[[knowles, Knowles 1970]]] M. S. Knowles, _The Modern Practice of Adult Education: Andragogy versus Pedagogy._ New York, NY, USA: Association Press, 1970.
 
-- [[[knowles, Knowles 1970]]] Malcolm S. (1970) The Modern Practice of Adult Education: Andragogy versus Pedagogy, Associated Press, New York. 
-
+// L
 // especially recommend the LS Menu
-- [[[libstruc, LibStruc]]] Liberating Structures to plan and facilitate exercises and make the training more interactive: https://www.liberatingstructures.com/
+- [[[libstruc, LibStruc]]] "Liberating Structures." [Online]. Available: https://www.liberatingstructures.com/
 
-- [[[katas2, Neward+]]] Ted Neward and contributors: Architectural Katas, <http://www.architecturalkatas.com/>.
+// M
+- [[[mccarthy, McCarthy 2000]]] B. McCarthy, _About Teaching: 4MAT in the Classroom._ Wauconda, IL, USA: About Learning Inc., 2000.
 
-- [[[mccarthy, McCarthy 2000]]] McCarthy, B.: About Teaching: 4MAT in the Classroom (English Edition). About Learning, Inc., 2000
+// N
+- [[[katas_neward, Neward+]]] T. Neward et al., "Architectural Katas." [Online]. Available: http://www.architecturalkatas.com/
 
-- [[[katas1, Richards+]]] Mark Richards, Neal Ford: Architectural Katas, <http://fundamentalsofsoftwarearchitecture.com/katas/>.
+// R
+- [[[katas1, Richards+]]] M. Richards and N. Ford, "Architectural Katas." [Online]. Available: http://fundamentalsofsoftwarearchitecture.com/katas/
+- [[[richards_fundamentals, Richards+2020]]] M. Richards and N. Ford, _Fundamentals of Software Architecture: An Engineering Approach_. Boston, MA, USA: O'Reilly, 2020.
 
-- [[[richards, Richards+2020]]] Richards, Mark; Ford, Neal.: Fundamentals of Software Architecture: An Engineering Approach (English Edition), 2020
+// S
+- [[[arc42BE1, Starke+2023]]] G. Starke, M. Simons, S. Zörner, R. D. Müller, and H. Lösch, _arc42 by Example_, 3rd ed. [Online]. Available: https://leanpub.com/arc42byexample
+- [[[starke, Starke 2024]]] G. Starke, _Effektive Software-Architekturen - Ein praktischer Leitfaden_, 10th ed. Munich, Germany: Carl Hanser Verlag, 2024. Website: https://esabuch.de
 
-- [[[arc42BE1, Starke+2023]]] Gernot Starke, Michael Simons, Stefan Zörner, Ralf D. Müller und Hendrik Lösch: arc42 by Example - 3rd edition, published by Leanpub, <https://leanpub.com/arc42byexample>. 
-
-- [[[starke, Starke2024]]] G. Starke, _Effektive Software-Architekturen - Ein praktischer Leitfaden_, 10th ed. Munich, Germany: Carl Hanser Verlag, 2024. Website: https://esabuch.de
-
-
-- [[[tttgithub, T3GitHub]]] GitHub Repository of the Train-the-Trainer Curriculum. https://github.com/isaqb-org/curriculum-t3
+// T
+- [[[tttgithub, T3GitHub]]] iSAQB, "Train-the-Trainer Curriculum," GitHub repository. [Online]. Available: https://github.com/isaqb-org/curriculum-t3
 
 // tag::EN[]
 // Keep to avoid warning for missing EN tag


### PR DESCRIPTION
Had to redact the parts for "Architecture Teaching References - Modern Sources for Teaching Architectural Thinking" a bit as the provided references to LU03 LGs didn't make sense to me.
@DenHerrRing Please check (also the other parts) thoroughly for correctness.

I would really like to merge this PR as soon as reasonable, as the Bibliography section might get additional entries for other LUs and I don't want to deal with a lot of merge conflicts.